### PR TITLE
Fix sky96 build script

### DIFF
--- a/sky96/m64p_test.sh
+++ b/sky96/m64p_test.sh
@@ -21,5 +21,5 @@
 # * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 cd test
-./mupen64plus ./m64p_test_rom.v64
+./sky96 ./m64p_test_rom.v64
 

--- a/sky96/source/mupen64plus-ui-console/projects/unix/Makefile
+++ b/sky96/source/mupen64plus-ui-console/projects/unix/Makefile
@@ -325,20 +325,20 @@ install: $(TARGET)
 	$(INSTALL) -d "$(DESTDIR)$(BINDIR)"
 	$(INSTALL) -m 0755 $(INSTALL_STRIP_FLAG) $(TARGET) "$(DESTDIR)$(BINDIR)"
 	$(INSTALL) -d "$(DESTDIR)$(MANDIR)/man6"
-       $(INSTALL) -m 0644 $(SRCDIR)/../doc/sky96.6 "$(DESTDIR)$(MANDIR)/man6"
+	$(INSTALL) -m 0644 $(SRCDIR)/../doc/sky96.6 "$(DESTDIR)$(MANDIR)/man6"
 	$(INSTALL) -d "$(DESTDIR)$(APPSDIR)"
-       $(INSTALL) -m 0644 $(SRCDIR)/../data/sky96.desktop "$(DESTDIR)$(APPSDIR)"
+	$(INSTALL) -m 0644 $(SRCDIR)/../data/sky96.desktop "$(DESTDIR)$(APPSDIR)"
 	$(INSTALL) -d "$(DESTDIR)$(ICONSDIR)/48x48/apps"
-       $(INSTALL) -m 0644 $(SRCDIR)/../data/icons/48x48/apps/sky96.png "$(DESTDIR)$(ICONSDIR)/48x48/apps"
+	$(INSTALL) -m 0644 $(SRCDIR)/../data/icons/48x48/apps/sky96.png "$(DESTDIR)$(ICONSDIR)/48x48/apps"
 	$(INSTALL) -d "$(DESTDIR)$(ICONSDIR)/scalable/apps"
-       $(INSTALL) -m 0644 $(SRCDIR)/../data/icons/scalable/apps/sky96.svg "$(DESTDIR)$(ICONSDIR)/scalable/apps"
+	$(INSTALL) -m 0644 $(SRCDIR)/../data/icons/scalable/apps/sky96.svg "$(DESTDIR)$(ICONSDIR)/scalable/apps"
 
 
 uninstall:
-       $(RM) "$(DESTDIR)$(BINDIR)/$(TARGET)" "$(DESTDIR)$(MANDIR)/man6/sky96.6"
-       $(RM) "$(DESTDIR)$(APPSDIR)/sky96.desktop"
-       $(RM) "$(DESTDIR)$(ICONSDIR)/48x48/apps/sky96.png"
-       $(RM) "$(DESTDIR)$(ICONSDIR)/scalable/apps/sky96.svg"
+	$(RM) "$(DESTDIR)$(BINDIR)/$(TARGET)" "$(DESTDIR)$(MANDIR)/man6/sky96.6"
+	$(RM) "$(DESTDIR)$(APPSDIR)/sky96.desktop"
+	$(RM) "$(DESTDIR)$(ICONSDIR)/48x48/apps/sky96.png"
+	$(RM) "$(DESTDIR)$(ICONSDIR)/scalable/apps/sky96.svg"
 
 
 # build dependency files


### PR DESCRIPTION
## Summary
- fix indentation in sky96 Makefile so `make` recognizes commands
- update the test script to run the renamed `sky96` binary

## Testing
- `./m64p_build.sh`
- `./m64p_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868deca9874832885ad4de57971213c