### PR TITLE
Fix analysis tool include path

### DIFF
--- a/sky96/source/mupen64plus-ui-console/src/main.c
+++ b/sky96/source/mupen64plus-ui-console/src/main.c
@@ -34,7 +34,7 @@
 #include <SDL_main.h>
 #include <SDL_thread.h>
 #include <dlfcn.h>
-#include "../../../analysis_tool/include/analysis_window.h"
+#include "../../../../analysis_tool/include/analysis_window.h"
 
 #include "cheat.h"
 #include "compare_core.h"


### PR DESCRIPTION
## Summary
- fix header include path in sky96 ui-console
- build analysis_tool and run tests

## Testing
- `cmake -S analysis_tool -B analysis_tool/build`
- `cmake --build analysis_tool/build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_686da010eee4832895c3b17614c99dca