### PR TITLE
Add Sky96 build and run helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# N64 Real-Time Analysis Tool Quickstart
+
+This repository contains the Sky96 emulator and a small analysis plugin.
+Use the `run_sky96.sh` script to install everything, build the emulator
+and plugin, and launch the test ROM with the analysis window enabled.
+
+```bash
+./run_sky96.sh
+```
+
+The script installs required build packages using `apt`, compiles all
+Sky96 components (including video and audio plugins), builds the
+`analysis_tool` project, runs its tests via `ctest`, and finally starts
+the emulator with `my_original_rom1.z64`.

--- a/run_sky96.sh
+++ b/run_sky96.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Script to install dependencies, build Sky96 and the analysis tool,
+# then run the emulator with the test ROM.
+# Exits immediately on any error and prints the failing line number.
+set -euo pipefail
+
+error_exit() {
+    echo "Error on line $1" >&2
+    exit 1
+}
+trap 'error_exit $LINENO' ERR
+
+# Step 1: Install build dependencies
+echo "Installing build dependencies..."
+sudo apt update
+sudo apt install -y build-essential libsdl2-dev libpng-dev libfreetype6-dev libz-dev
+
+# Step 2: Build and install Sky96 and all plugins
+cd "$(dirname "$0")/sky96"
+echo "Building Sky96 and plugins..."
+./m64p_build.sh
+
+echo "Installing Sky96..."
+./m64p_install.sh
+
+# Step 3: Build the analysis tool
+cd ../analysis_tool
+mkdir -p build
+cd build
+echo "Configuring analysis tool..."
+cmake ..
+echo "Compiling analysis tool..."
+make
+
+# Step 4: Run analysis tool tests
+ctest
+
+# Step 5: Launch Sky96 with analysis tool and test ROM
+cd ../../sky96/test
+echo "Launching Sky96 with analysis tool..."
+./sky96 ../../my_original_rom1.z64


### PR DESCRIPTION
## Summary
- add `run_sky96.sh` to automate dependency install, build and launch of Sky96 with the analysis plugin
- document quickstart usage in a new root README

## Testing
- `cmake .. && make && ctest` in `analysis_tool/build`

------
https://chatgpt.com/codex/tasks/task_e_686e9b2b80248328bc23fdfc35d2b1ed