### PR TITLE
Fix close handling and cursor

### DIFF
--- a/analysis_tool/tests/dummy_test.cpp
+++ b/analysis_tool/tests/dummy_test.cpp
@@ -1,7 +1,11 @@
 #include "analysis_window.h"
+#include <chrono>
+#include <thread>
+
 int main() {
-    // just ensure the API can be linked
+    setenv("SDL_VIDEODRIVER", "dummy", 1);
     analysis_window_start(nullptr);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     analysis_window_stop();
     return 0;
 }


### PR DESCRIPTION
## Summary
- handle window events only for analysis tool
- show the system cursor while analysis window is open
- ensure events are passed to Sky96
- run analysis window briefly in tests to check start/stop

## Testing
- `cmake ..`
- `make`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_686e9f00e5a88328bebc980090cd73a9