### PR TITLE
Add analysis tool build helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Build artifacts
+analysis_tool/build/
+*.log

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ The script installs required build packages using `apt`, compiles all
 Sky96 components (including video and audio plugins), builds the
 `analysis_tool` project, runs its tests via `ctest`, and finally starts
 the emulator with `my_original_rom1.z64`.
+
+For rapid iteration on the analysis tool alone, first configure it once
+with CMake, then use the `build_analysis_tool.sh` script to rebuild and
+run its tests without touching the emulator:
+
+```bash
+./build_analysis_tool.sh
+```

--- a/build_analysis_tool.sh
+++ b/build_analysis_tool.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Build the analysis_tool quickly without rebuilding the emulator.
+set -euo pipefail
+
+error_exit() {
+    echo "Error on line $1" >&2
+    exit 1
+}
+trap 'error_exit $LINENO' ERR
+
+# Navigate to the existing build directory. Assume it has already been configured.
+cd "$(dirname "$0")/analysis_tool"
+mkdir -p build
+cd build
+
+# Compile the analysis tool
+cmake --build .
+
+# Run tests
+ctest


### PR DESCRIPTION
## Summary
- add a dedicated script for rebuilding the analysis tool without rebuilding the emulator
- document the helper script in the README
- ignore build artifacts

## Testing
- `./build_analysis_tool.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ea4c1bee08328ad3dc12b132ba7cf