### PR TITLE
Fix invisible cursor in analysis window

### DIFF
--- a/analysis_tool/CMakeLists.txt
+++ b/analysis_tool/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(analysis_tool PRIVATE SDL2::SDL2)
 
 add_executable(dummy_test tests/dummy_test.cpp)
 target_include_directories(dummy_test PRIVATE include ../sky96/source/mupen64plus-core/src/api)
-target_link_libraries(dummy_test PRIVATE analysis_tool)
+target_link_libraries(dummy_test PRIVATE analysis_tool SDL2::SDL2)
 
 enable_testing()
 add_test(NAME dummy_test COMMAND dummy_test)

--- a/analysis_tool/src/AnalysisWindow.cpp
+++ b/analysis_tool/src/AnalysisWindow.cpp
@@ -10,6 +10,9 @@ static core_do_command_func coreCmd = nullptr;
 
 static void window_loop()
 {
+    int prevCursorState = SDL_ShowCursor(SDL_QUERY);
+    SDL_bool prevRelativeMode = SDL_GetRelativeMouseMode();
+
     SDL_Window* win = SDL_CreateWindow("Analysis Tool", SDL_WINDOWPOS_CENTERED,
         SDL_WINDOWPOS_CENTERED, 320, 240, SDL_WINDOW_SHOWN);
     if (!win)
@@ -17,6 +20,7 @@ static void window_loop()
         fprintf(stderr, "Failed to create analysis window: %s\n", SDL_GetError());
         return;
     }
+    SDL_SetRelativeMouseMode(SDL_FALSE);
     SDL_ShowCursor(SDL_ENABLE);
     Uint32 windowID = SDL_GetWindowID(win);
 
@@ -62,7 +66,8 @@ static void window_loop()
         SDL_Delay(16);
     }
     SDL_DestroyWindow(win);
-    SDL_ShowCursor(SDL_DISABLE);
+    SDL_SetRelativeMouseMode(prevRelativeMode);
+    SDL_ShowCursor(prevCursorState ? SDL_ENABLE : SDL_DISABLE);
 }
 
 extern "C" void analysis_window_start(core_do_command_func cmd)

--- a/analysis_tool/tests/dummy_test.cpp
+++ b/analysis_tool/tests/dummy_test.cpp
@@ -1,11 +1,26 @@
 #include "analysis_window.h"
+#include <SDL.h>
 #include <chrono>
 #include <thread>
 
 int main() {
     setenv("SDL_VIDEODRIVER", "dummy", 1);
+    if (SDL_Init(SDL_INIT_VIDEO) != 0)
+        return 1;
+
+    SDL_SetRelativeMouseMode(SDL_TRUE);
+
     analysis_window_start(nullptr);
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    bool cursorVisible = SDL_ShowCursor(SDL_QUERY) == SDL_ENABLE;
+    bool relativeMode = SDL_GetRelativeMouseMode();
+
     analysis_window_stop();
+    SDL_Quit();
+
+    if (!cursorVisible || relativeMode)
+        return 1;
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- ensure the analysis window disables relative mouse mode so the cursor is visible
- preserve the previous cursor and mouse mode state when closing
- link SDL2 in the test and update the dummy test to verify cursor visibility

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_686ea850337c8328bdd2f4e5e5c90d13